### PR TITLE
Remove deprecated installcharts to fix build

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -51,7 +51,6 @@ withPipeline(type, product, app) {
     overrideVaultEnvironments(vaultOverrides)
     loadVaultSecrets(secrets)
     enableDbMigration('ctsc')
-    installCharts()
     enableSlackNotifications('#ctstc-tech-internal')
     disableLegacyDeployment()
     enableAksStagingDeployment()


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A

### Change description ###
Remove installcharts() from jenkinsfile to resolve the following error:

[2020-07-22T13:37:49.316Z] java.lang.RuntimeException: installCharts() is deprecated and no longer does anything, please remove this flag before the pipeline starts failing.,This change is enforced from 25/05/2020 00:00 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
