### PR TITLE
Remove terraform_remote_state references

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -8,7 +8,6 @@ locals {
     map(
       "Team Name", "CTSC"
   ))}"
-  ase_name  = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
   vaultName = "${var.product}-${var.env}"
   asp_name  = "${var.product}-${var.env}"
 }

--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -2,24 +2,3 @@ terraform {
   backend "azurerm" {}
 }
 
-data "terraform_remote_state" "core_apps_infrastructure" {
-  backend = "azurerm"
-
-  config {
-    resource_group_name  = "mgmt-state-store-${var.subscription}"
-    storage_account_name = "mgmtstatestore${var.subscription}"
-    container_name       = "mgmtstatestorecontainer${var.env}"
-    key                  = "core-infra/${var.env}/terraform.tfstate"
-  }
-}
-
-data "terraform_remote_state" "core_apps_compute" {
-  backend = "azurerm"
-
-  config {
-    resource_group_name  = "mgmt-state-store-${var.subscription}"
-    storage_account_name = "mgmtstatestore${var.subscription}"
-    container_name       = "mgmtstatestorecontainer${var.env}"
-    key                  = "core-compute/${var.env}/terraform.tfstate"
-  }
-}


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

    Remove terraform_remote_state references to fix the following build error

    data.terraform_remote_state.core_apps_infrastructure: data.terraform_remote_state.core_apps_infrastructure: Terraform 0.11.7 does not support state version 4, please update.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
