### PR TITLE
CTSCT-48 Bump org.owasp.dependencycheck from 5.3.2.1 to 6.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.10.RELEASE'
   id 'org.springframework.boot' version '2.3.3.RELEASE'
-  id 'org.owasp.dependencycheck' version '5.3.2.1'
+  id 'org.owasp.dependencycheck' version '6.0.0'
   id 'com.github.ben-manes.versions' version '0.31.0'
   id 'org.sonarqube' version '3.0'
   id "io.freefair.lombok" version "5.2.1"

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -75,6 +75,8 @@
       <cve>CVE-2020-9546</cve>
       <cve>CVE-2020-9547</cve>
       <cve>CVE-2020-9548</cve>
+      <cve>CVE-2020-10663</cve>
+      <cve>CVE-2020-7712</cve>
     </suppress>
     <suppress>
       <notes><![CDATA[file name: commons-collections-3.2.1.jar]]></notes>
@@ -96,17 +98,8 @@
       <cve>CVE-2020-9488</cve>
     </suppress>
     <suppress>
-        <packageUrl regex="true">pkg:maven/net.minidev/accessors-smart@1.2</packageUrl>
-        <cve>CVE-2020-10663</cve>
-    </suppress>
-    <suppress>
-        <packageUrl regex="true">pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.3.RELEASE</packageUrl>
-        <cve>CVE-2020-7712</cve>
-    </suppress>
-    <suppress>
         <packageUrl regex="true">pkg:maven/com.nimbusds/oauth2-oidc-sdk@7.1.1</packageUrl>
         <cve>CVE-2007-1651</cve>
         <cve>CVE-2007-1652</cve>
     </suppress>
-
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -95,4 +95,18 @@
       <cve>CVE-2020-13934</cve>
       <cve>CVE-2020-9488</cve>
     </suppress>
+    <suppress>
+        <packageUrl regex="true">pkg:maven/net.minidev/accessors-smart@1.2</packageUrl>
+        <cve>CVE-2020-10663</cve>
+    </suppress>
+    <suppress>
+        <packageUrl regex="true">pkg:maven/net.minidev/json-smart@2.3</packageUrl>
+        <cve>CVE-2020-7712</cve>
+    </suppress>
+    <suppress>
+        <packageUrl regex="true">pkg:maven/com.nimbusds/oauth2-oidc-sdk@7.1.1</packageUrl>
+        <cve>CVE-2007-1651</cve>
+        <cve>CVE-2007-1652</cve>
+    </suppress>
+
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -100,7 +100,7 @@
         <cve>CVE-2020-10663</cve>
     </suppress>
     <suppress>
-        <packageUrl regex="true">pkg:maven/net.minidev/json-smart@2.3</packageUrl>
+        <packageUrl regex="true">pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.3.RELEASE</packageUrl>
         <cve>CVE-2020-7712</cve>
     </suppress>
     <suppress>


### PR DESCRIPTION



### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CTSCT-48


### Change description ###
Bump org.owasp.dependencycheck from 5.3.2.1 to 6.0.0


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
