### PR TITLE
Revert: Bump applicationinsights-logging-logback from 2.6.1 to 2.6.2 …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,7 +202,7 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.reformLogging
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.5.RELEASE'
   compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '3.4.0'
-  compile group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.2'
+  compile group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.1'
   compile group: 'org.springframework.retry', name: 'spring-retry', version: '1.3.0'
 
   compile group: 'org.postgresql', name: 'postgresql', version: '42.2.16'


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CTSCT-57


### Change description ###
Reverting Bump applicationinsights-logging-logback from 2.6.1 to 2.6.2 - its breaking the change.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
