### PR TITLE
Bump flyway core from 6.5.5 to 7.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,7 +213,7 @@ dependencies {
   compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.11.3'
 
   compile group: 'io.vavr', name: 'vavr', version: '0.10.3'
-  compile group: 'org.flywaydb', name: 'flyway-core', version: '6.5.5'
+  compile group: 'org.flywaydb', name: 'flyway-core', version: '7.0.0'
 
 
   testCompile group: 'io.rest-assured', name: 'rest-assured', version: '4.3.1'

--- a/build.gradle
+++ b/build.gradle
@@ -12,13 +12,13 @@ plugins {
   id 'application'
   id 'checkstyle'
   id 'jacoco'
+  id 'org.flywaydb.flyway' version '7.0.0'
   id 'io.spring.dependency-management' version '1.0.10.RELEASE'
   id 'org.springframework.boot' version '2.3.4.RELEASE'
   id 'org.owasp.dependencycheck' version '6.0.2'
   id 'com.github.ben-manes.versions' version '0.33.0'
   id 'org.sonarqube' version '3.0'
   id "io.freefair.lombok" version "5.2.1"
-  id 'org.flywaydb.flyway' version '7.0.0'
 }
 
 apply plugin: 'net.serenity-bdd.aggregator'


### PR DESCRIPTION


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CTSCT-54


### Change description ###
Bumps flyway-core from 6.5.5 to 7.0.0.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
