### PR TITLE
DTSBPS-221: bumping dependencycheck from 6.0.2 to 6.0.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.10.RELEASE'
   id 'org.springframework.boot' version '2.3.4.RELEASE'
-  id 'org.owasp.dependencycheck' version '6.0.2'
+  id 'org.owasp.dependencycheck' version '6.0.3'
   id 'com.github.ben-manes.versions' version '0.33.0'
   id 'org.sonarqube' version '3.0'
   id "io.freefair.lombok" version "5.2.1"

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -102,4 +102,18 @@
         <cve>CVE-2007-1651</cve>
         <cve>CVE-2007-1652</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: tomcat-embed-core-9.0.38.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
+        <cve>CVE-2020-13943</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: tomcat-embed-websocket-9.0.38.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
+        <cve>CVE-2020-13943</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION



### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-221


### Change description ###
Bump org.owasp.dependencycheck from 6.0.2 to 6.0.3


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
