### PR TITLE
DTSBPS-246: Bump org.springframework.boot from 2.3.5.RELEASE to 2.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
   id 'checkstyle'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.10.RELEASE'
-  id 'org.springframework.boot' version '2.3.5.RELEASE'
+  id 'org.springframework.boot' version '2.4.0'
   id 'org.owasp.dependencycheck' version '6.0.3'
   id 'com.github.ben-manes.versions' version '0.36.0'
   id 'org.sonarqube' version '3.0'
@@ -194,6 +194,7 @@ dependencies {
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-json'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
+  compile group: 'org.springframework.boot', name: 'spring-boot-starter-mail'
   compile group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.2'
   compile group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.1.0'
 


### PR DESCRIPTION


### JIRA link (if applicable) ###
DTSBPS-246


### Change description ###
Bump org.springframework.boot from 2.3.5.RELEASE to 2.4.0
Added spring-boot-starter-mail dependency as it is isolate from main boot.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
