### PR TITLE
DTSBPS-495: lib upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,12 @@ plugins {
   id 'checkstyle'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.4.4'
+  id 'org.springframework.boot' version '2.4.5'
   id 'org.owasp.dependencycheck' version '6.1.5'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.1.1'
   id "io.freefair.lombok" version "5.3.3.3"
-  id 'org.flywaydb.flyway' version '7.7.2'
+  id 'org.flywaydb.flyway' version '7.8.0'
 }
 
 apply plugin: 'net.serenity-bdd.aggregator'
@@ -157,7 +157,7 @@ dependencyManagement {
     dependencySet(group: 'com.google.guava', version: '30.1.1-jre') {
       entry 'guava'
     }
-    dependencySet(group: 'io.netty', version: '4.1.61.Final') {
+    dependencySet(group: 'io.netty', version: '4.1.63.Final') {
       entry 'netty-buffer'
       entry 'netty-codec'
       entry 'netty-codec-http'
@@ -217,7 +217,7 @@ dependencies {
   compile group: 'io.springfox', name: 'springfox-boot-starter', version: '3.0.0'
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.7.RELEASE'
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.reformLogging
-  compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '3.6.1'
+  compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '3.6.2'
   compile group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.3'
   compile group: 'org.springframework.retry', name: 'spring-retry', version: '1.3.1'
 
@@ -225,11 +225,11 @@ dependencies {
 
   compile group: 'org.apache.velocity', name: 'velocity', version: '1.7'
 
-  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: '2.12.2'
-  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.2'
+  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: '2.12.3'
+  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.3'
 
   compile group: 'io.vavr', name: 'vavr', version: '0.10.3'
-  compile group: 'org.flywaydb', name: 'flyway-core', version: '7.7.2'
+  compile group: 'org.flywaydb', name: 'flyway-core', version: '7.8.0'
 
 
   testCompile group: 'io.rest-assured', name: 'rest-assured', version: '4.3.3'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-495


### Change description ###

- Bump org.flywaydb.flyway from 7.7.2 to 7.8.0
- Bump flyway-core from 7.7.2 to 7.8.0 
- Bump org.springframework.boot from 2.4.4 to 2.4.5
- Bump jackson-datatype-jsr310 from 2.12.2 to 2.12.3
- Bump jackson-datatype-jdk8 from 2.12.2 to 2.12.3 
- Bump azure-servicebus from 3.6.1 to 3.6.2
- Bump io.netty dependency set from 4.1.61.Final to 4.1.63.Final 



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
