### PR TITLE
DTSPO-6371 add private endpoint provider for service bus

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -113,7 +113,7 @@ resource "azurerm_resource_group" "rg" {
 
 module "servicebus-namespace" {
   providers = {
-    azurerm.private-endpoint = azurerm.private-endpoint
+    azurerm.private_endpoint = azurerm.private_endpoint
   }
 
   source              = "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=master"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -112,6 +112,10 @@ resource "azurerm_resource_group" "rg" {
 }
 
 module "servicebus-namespace" {
+  providers = {
+    azurerm.private-endpoint = azurerm.private-endpoint
+  }
+
   source              = "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=master"
   name                = "${var.product}-servicebus-${var.env}"
   location            = var.location_app

--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -15,6 +15,6 @@ terraform {
 provider "azurerm" {
   features {}
   skip_provider_registration = true
-  alias                      = "private-endpoint"
+  alias                      = "private_endpoint"
   subscription_id            = var.aks_subscription_id
 }

--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -12,3 +12,9 @@ terraform {
   }
 }
 
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+  alias                      = "private-endpoint"
+  subscription_id            = var.aks_subscription_id
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -103,3 +103,5 @@ variable "last_modified_minus_minutes" {
 variable "ccd_dry_run" {
   default = "true"
 }
+
+variable "aks_subscription_id" {}


### PR DESCRIPTION
# JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-6371


### Change description ###
PlatOps have made some changes to the service bus terraform module, mainly around adding the ability to enable private endpoints. We needed to add a Private Endpoint provider to allow for Private endpoints being deployed to a different Subscription to the Service Bus being created. 

This change should have no effect on anything currently deployed, but it will allow you to deploy a Service Bus with a Private Endpoint if you add the correct inputs to the module. 

More information on that can be found here: https://github.com/hmcts/terraform-module-servicebus-namespace#usage


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
